### PR TITLE
TypeError: Data.__init__() got an unexpected keyword argument 'cacc'

### DIFF
--- a/train.ipynb
+++ b/train.ipynb
@@ -43,7 +43,7 @@
    "source": [
     "# Install packages\n",
     "\n",
-    "!pip install ksim==0.1.2 xax==0.3.0 mujoco-scenes"
+    "!pip install ksim==0.1.2 xax==0.3.0 mujoco==3.3.2 mujoco-scenes"
    ]
   },
   {


### PR DESCRIPTION
mujoco 3.3.3 causing error.  Forced mujoco 3.3.2 instead of latest.  [https://github.com/kscalelabs/ksim-gym/issues/49](url)